### PR TITLE
feat: Remove specified product categories and filters

### DIFF
--- a/public/produits.json
+++ b/public/produits.json
@@ -1,16 +1,6 @@
 {
     "products": [
         {
-            "id": 1,
-            "name": "Crème Visage à la Bave d'Escargot",
-            "image": "/images/catalogue/creme-visage.jpg",
-            "hint": "face cream",
-            "price": 38,
-            "category": "catalogue",
-            "subCategory": "creme-de-visage",
-            "description": "Un soin régénérant et hydratant d'exception pour une peau visiblement plus jeune et éclatante."
-        },
-        {
             "id": 2,
             "name": "Masque Cheveux à la Kératine",
             "image": "/images/catalogue/masque-cheveux.jpg",
@@ -47,24 +37,6 @@
             "description": "Illuminez votre peau et vos cheveux d'un voile pailleté et parfumé pour un effet glamour assuré."
         },
         {
-            "id": 6,
-            "name": "Détartrant pour Machine à Café",
-            "image": "/images/catalogue/detartrant.jpg",
-            "hint": "cleaning product",
-            "price": 12,
-            "category": "catalogue",
-            "description": "Prolongez la durée de vie de votre machine à café et retrouvez le goût authentique de vos expressos."
-        },
-        {
-            "id": 7,
-            "name": "Nettoyant Four et Plaque de Cuisson",
-            "image": "/images/catalogue/nettoyant-four.jpg",
-            "hint": "oven cleaner",
-            "price": 15,
-            "category": "catalogue",
-            "description": "Éliminez les graisses les plus tenaces sans effort pour un four et des plaques de cuisson impeccables."
-        },
-        {
             "id": 8,
             "name": "Parfum d'Ambiance Bois d'Orient",
             "image": "/images/catalogue/parfum-ambiance.jpg",
@@ -72,16 +44,6 @@
             "price": 20,
             "category": "catalogue",
             "description": "Créez une atmosphère chaleureuse et envoûtante dans votre intérieur avec ce parfum d'ambiance aux notes boisées."
-        },
-        {
-            "id": 40,
-            "name": "Déodorant Fraîcheur 24h",
-            "image": "/images/catalogue/deodorant.jpg",
-            "hint": "deodorant",
-            "price": 15,
-            "category": "catalogue",
-            "subCategory": "deodorant",
-            "description": "Restez frais et confiant toute la journée avec notre déodorant efficacité 24h, sans sels d'aluminium."
         },
         {
             "id": 9,
@@ -234,76 +196,6 @@
             "description": "Une fragrance douce et pétillante, idéale pour celles et ceux qui aiment se chouchouter avec des senteurs gourmandes et raffinées. Enrichi d'accords délicieusement vanillés, ce parfum envoûte les sens avec ses notes irrésistibles."
         },
         {
-            "id": 29,
-            "name": "MYVERA CRUSH Keto + Complément alimentaire",
-            "image": "https://orianacosmetic.com/cdn/shop/files/MYVERA-CRUSH-Keto-_-Complement-alimentaire_Chogan-263468460.png?v=1754103207&width=355",
-            "hint": "detox tea",
-            "price": 54.9,
-            "category": "minceur",
-            "description": "MYVERA CRUSH Keto + est un complément alimentaire cétogène au goût cola, à base de pulpe d’aloe vera et de vitamine C, enrichi en caféine, en édulcorants naturels et en extraits végétaux puissants. Grâce au complexe breveté ALO-COMPLEX™, il exerce une action purifiante et antioxydante sur l’organisme. Sa formule unique est conçue pour soutenir le métabolisme, réduire la fatigue, tonifier le corps et aider à stabiliser le poids. Riche en vitamines B6, B12 et C, en guarana, en L-carnitine, en taurine et en Uncaria Tomentosa, il constitue un allié précieux pour les personnes actives ou suivant un régime cétogène.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 30,
-            "name": "MYVERA CRUSH Mind + Complément alimentaire nootropique",
-            "image": "https://orianacosmetic.com/cdn/shop/files/MYVERA-CRUSH-Mind-_-Complement-alimentaire-nootropique_Chogan-263467129.png?v=1754103128&width=355",
-            "hint": "fat burner supplement",
-            "price": 44.9,
-            "category": "minceur",
-            "description": "MYVERA CRUSH Mind + est un complément alimentaire nootropique conçu pour soutenir les fonctions cognitives, la mémoire et la concentration. Sa formule associe des ingrédients reconnus pour leurs effets sur la vigilance et les performances mentales, comme la citicoline, la guarana, la centella et la carnitine. Enrichi en aloe vera et en vitamine C, réunis dans le complexe exclusif ALO-COMPLEX™, il exerce également une action purifiante et antioxydante sur l’organisme. Avec son goût agréable de pomme, ce complément est idéal pour renforcer naturellement les capacités mentales au quotidien.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 31,
-            "name": "SKINAIL PLUS - Complément alimentaire en gel Pour la peau, les cheveux et les ongles",
-            "image": "https://orianacosmetic.com/cdn/shop/files/SKINAIL-PLUS-Complement-alimentaire-en-gel_Chogan-264903540.png?v=1754103493&width=355",
-            "hint": "protein shake",
-            "price": 81.9,
-            "category": "minceur",
-            "description": "Skinail Plus est un complément alimentaire prêt à l'emploi, aromatisé à la vanille, sous forme de gel. Il est conçu pour le bien-être et la beauté de la peau, des cheveux et des ongles. Sa formule à base de collagène, de vitamines B, de vitamine C et d'acide hyaluronique aide à maintenir la peau hydratée, souple et tonique, tout en prévenant la formation de taches cutanées et de rides.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 32,
-            "name": "VIRILGEL – Complément alimentaire en gel Aux propriétés toniques et stimulantes",
-            "image": "https://orianacosmetic.com/cdn/shop/files/VIRILGEL-_-Complement-alimentaire-en-gel_Chogan-264922250.png?v=1754103504&width=690",
-            "hint": "anti-cellulite cream",
-            "price": 74.9,
-            "category": "minceur",
-            "description": "Virilgel est un complément alimentaire prêt à l'emploi, aromatisé à la banane, sous forme de gel, formulé pour exercer une forte activité tonico-adaptogène. Il contient le mélange innovant breveté VIRILPIU™, composé d'extraits végétaux de Cacao, Schizandra, Maté et Maca Andina, qui soutiennent la lutte contre la fatigue physique et mentale. De plus, l'Arginine et la Citrulline agissent en synergie pour améliorer le bien-être masculin. Les ",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 33,
-            "name": "MYBRAIN - complément alimentaire en gel pour la mémoire et la concentration",
-            "image": "https://orianacosmetic.com/cdn/shop/files/MYBRAIN-complement-alimentaire-en-gel-pour-la-memoire-et-la-concentration_Chogan-264926798.png?v=1754103518&width=690",
-            "hint": "natural appetite suppressant",
-            "price": 57.9,
-            "category": "minceur",
-            "description": "MYBRAIN est un complément alimentaire prêt à l'emploi, sous forme de gel aromatisé à la réglisse. Il est formulé avec le complexe breveté MEMORY FOCUS™, un mélange d'extraits végétaux aux bienfaits ciblés sur les fonctions cognitives. Les extraits d'Éleuthérocoque, de Ginkgo Biloba et de Bacopa favorisent la mémoire et la concentration. L'extrait de Griffonia apporte un soutien au bien-être mental, tandis que la phosphosérine et les vitamines B5 et B12 contribuent aux performances mentales et à la réduction de la fatigue..",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 34,
-            "name": "DREN FAST - Complément alimentaire à base de caféine",
-            "image": "https://orianacosmetic.com/cdn/shop/files/DREN-FAST-Complement-alimentaire-a-base-de-cafeine_Chogan-264883617.png?v=1754103467&width=355",
-            "hint": "detox drink",
-            "price": 44.9,
-            "category": "minceur",
-            "description": "DREN FAST est un complément alimentaire drainant et antioxydant formulé avec Equitullas™, un complexe exclusif d’extraits de plantes, enrichi en caféine (20 mg par portion), conçu pour améliorer la microcirculation, réduire la rétention d’eau, lutter contre les imperfections de la cellulite, et renforcer la sensation de légèreté.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "name": "SPEEDSLEEP - Complément alimentaire en gel à base de Mélatonine",
-            "image": "https://orianacosmetic.com/cdn/shop/files/SPEEDSLEEP-Complement-alimentaire-en-gel-a-base-de-Melatonine_Chogan-264775925.png?v=1754103453&width=355",
-            "hint": "test hint",
-            "price": 27.9,
-            "category": "minceur",
-            "id": 3597,
-            "description": "SPEEDSLEEP est un complément alimentaire innovant sous forme de gel, conçu pour favoriser un sommeil réparateur et de qualité. Sa formule exclusive brevetée SOMNIWELL™ associe la mélatonine, reconnue pour réduire le temps d’endormissement, à des extraits de pavot de Californie, pavot rouge, passiflore, tilleul et griffonia, qui agissent ensemble pour apaiser le système nerveux, limiter les réveils nocturnes et soutenir la régularité du cycle veille-sommeil. Grâce à sa texture en gel et son goût agréable de figue, SPEEDSLEEP offre une absorption rapide et une efficacité optimale dès la prise.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
             "name": "DREN FAST - Pour l'équilibre du poids corporel",
             "image": "https://orianacosmetic.com/cdn/shop/files/DREN-FAST-Pour-l_equilibre-du-poids-corporel_Chogan-264890222.png?v=1754103480&width=355",
             "hint": "test hint",
@@ -312,146 +204,6 @@
             "id": 3676,
             "description": "DREN FAST est un complément alimentaire à action drainante, conçu pour accompagner efficacement les régimes destinés à rééquilibrer le poids corporel. Grâce à son complexe exclusif Equitullas™, un mélange synergique d'extraits de plantes, ce produit stimule le métabolisme, favorise la digestion et aide à éliminer les excès d'eau et les toxines. Les extraits de bouleau, orthosiphon, thé vert, ananas, artichaut ou encore raisin agissent ensemble pour purifier l'organisme, améliorer la circulation, réduire les ballonnements et atténuer la sensation de jambes lourdes. Avec DREN FAST, adoptez un rituel naturel pour vous sentir plus léger(e) et plein(e) d'énergie au quotidien..",
             "subCategory": "produit-minceur"
-        },
-        {
-            "name": "MULTIGELVIT - Complément alimentaire multivitaminé en gel",
-            "image": "https://orianacosmetic.com/cdn/shop/files/MULTIGELVIT-Complement-alimentaire-multivitamine-en-gel_Chogan-264737930.png?v=1754103440&width=355",
-            "hint": "test hint",
-            "price": 24.9,
-            "category": "minceur",
-            "id": 3700,
-            "description": "MULTIGELVIT est un complément alimentaire multivitaminé prêt à l’emploi, sous forme de gel aromatisé à la mandarine, conçu pour soutenir le bien-être général et les performances mentales. Grâce à sa formule brevetée IPERVITAMY™, il fournit un apport équilibré en vitamines B, C, H (Biotine), acide folique, et L-carnitine, contribuant à réduire la fatigue, renforcer le système immunitaire et soutenir le métabolisme énergétique.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "name": "DREN FAST Complément alimentaire pour le drainage des fluides corporels",
-            "image": "https://orianacosmetic.com/cdn/shop/files/DREN-FAST_Chogan-264501944.png?v=1754103284&width=355",
-            "hint": "test hint",
-            "price": 39,
-            "category": "minceur",
-            "id": 8638,
-            "description": "Dren Fast est un complément alimentaire spécialement conçu pour favoriser le drainage des fluides corporels. Enrichi avec Equitullas™, un mélange innovant d'extraits de plantes, il aide à détoxifier le corps, rétablir un métabolisme cellulaire optimal, et améliorer la circulation des fluides corporels. Ce produit contribue à une peau éclatante et à une élimination efficace des toxines et des déchets.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "name": "Collagène - Complément alimentaire Pour la peau, les cheveux, et les ongles",
-            "image": "https://orianacosmetic.com/cdn/shop/products/Collag_ne-Compl_ment-alimentaire-pour-la-peau_-les-cheveux_-et-les-ongles_Chogan-46884353.webp?v=1738492489&width=355",
-            "hint": "test hint",
-            "price": 139,
-            "category": "minceur",
-            "id": 1139,
-            "description": "SKINAIL COLLAGEN est un complément alimentaire formulé pour sublimer la peau, les cheveux et les ongles grâce au complexe breveté CBH-TOTAL™. Il associe collagène, vitamines B, zinc et extraits de plantes reconnues pour leurs bienfaits",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 999,
-            "name": "MYVERA CRUSH Collagen + Complément alimentaire beauté",
-            "image": "https://orianacosmetic.com/cdn/shop/files/MYVERA-CRUSH-Collagen-_-Complement-alimentaire-beaute_Chogan-263466926.png?v=1754103103&width=355",
-            "hint": "detox tea",
-            "price": 44.9,
-            "category": "minceur",
-            "description": "MYVERA CRUSH Collagen + est un complément alimentaire innovant conçu pour soutenir la beauté de la peau, des cheveux et des ongles. Formulé à base de jus et pulpe d’aloe vera, de vitamine C, de collagène hydrolysé, d’acide hyaluronique, de myrtille et de zinc, il constitue une synergie puissante réunie dans le complexe breveté ALO-COMPLEX™. Ce complexe agit en profondeur pour purifier l’organisme, favoriser l’hydratation de la peau, renforcer la microcirculation et prévenir les signes du vieillissement cutané. Grâce à son goût agréable de myrtille et sa formule liquide prête à consommer, MYVERA CRUSH Collagen + est un rituel quotidien idéal pour retrouver éclat, tonicité et vitalité.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 900,
-            "name": "MYVERA CRUSH Woman + Complément alimentaire",
-            "image": "https://orianacosmetic.com/cdn/shop/files/MYVERA-CRUSH-Woman-_-Complement-alimentaire_Chogan-263468214.png?v=1754103181&width=355",
-            "hint": "detox tea",
-            "price": 44.9,
-            "category": "minceur",
-            "description": "MYVERA CRUSH Woman + est un complément alimentaire tonique-adaptogène conçu pour soutenir la santé féminine. À base de jus et de pulpe d'Aloe Vera enrichis en vitamine C, ce produit se distingue par son mélange breveté ALO-COMPLEX™, offrant une action purifiante et antioxydante pour l'organisme. Il est formulé pour favoriser l'équilibre des hormones féminines, soutenir la fonction vasculaire et stimuler la production d'oxyde nitrique, un puissant vasodilatateur. Ce complément est également enrichi en extraits de Goji, d'Arginine, de Betterave et d'Éleuthérocoque, contribuant ainsi à renforcer l'énergie, à combattre la fatigue et à maintenir une vitalité optimale. Avec son goût agréable de fruits rouges, MYVERA CRUSH Woman + est idéal pour accompagner un mode de vie sain et dynamique. Disponible en flacons unidose de 285 ml, ce complément est conçu pour une consommation quotidienne, réfrigéré, afin de garantir une efficacité maximale.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 893,
-            "name": "MYVERA CRUSH Man + Complément alimentaire",
-            "image": "https://orianacosmetic.com/cdn/shop/files/MYVERA-CRUSH-Man-_-Complement-alimentaire_Chogan-263468091.png?v=1754103155&width=355",
-            "hint": "detox tea",
-            "price": 44.9,
-            "category": "minceur",
-            "description": "MYVERA CRUSH Man + est un complément alimentaire tonique-adaptogène, formulé pour soutenir naturellement les niveaux de testostérone et favoriser le bien-être masculin. Composé de jus et de pulpe d'Aloe Vera, de vitamine C et d'extraits végétaux tels que le Goji, l'Arginine, la betterave et l'Éleuthérocoque, ce produit est conçu pour améliorer la vitalité, l'énergie et les performances physiques. Il aide également à lutter contre la fatigue et à maintenir une production active d'oxyde nitrique, un puissant vasodilatateur, pour optimiser la circulation sanguine et soutenir les fonctions cognitives. Ce complément est enrichi du breveté ALO-COMPLEX™, offrant une action purifiante et antioxydante. MYVERA CRUSH Man + est idéal pour ceux recherchant un soutien énergétique et cognitif optimal dans un format pratique en flacons unidose de 285 ml.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 765,
-            "name": "MYVERA CRUSH - Wellness Discovery",
-            "image": "https://orianacosmetic.com/cdn/shop/files/MYVERA-CRUSH-Man-_-Complement-alimentaire_Chogan-263468091.png?v=1754103155&width=355",
-            "hint": "detox tea",
-            "price": 45.9,
-            "category": "minceur",
-            "description": "MYVERA CRUSH Collagen + est un complément alimentaire au goût délicieux de myrtille, à base de jus et de pulpe d’aloe vera et de vitamine C, réunis dans le complexe exclusif breveté ALO-COMPLEX™. Cette formule innovante est conçue pour favoriser la beauté de la peau, des cheveux et des ongles",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 567,
-            "name": "SUPPLEFIT ISO-WHEY",
-            "image": "https://orianacosmetic.com/cdn/shop/files/SUPPLEFIT-ISO-WHEY_Chogan-265462936.png?v=1754103582&width=355",
-            "hint": "detox tea",
-            "price": 44.9,
-            "category": "minceur",
-            "description": "SuppleFit Iso-Whey est un complément alimentaire à base de protéines natives isolées du lactosérum, conçu pour aider à renforcer et construire le tissu musculaire. Sa formule est enrichie en magnésium, pour réduire la fatigue et favoriser la synthèse des protéines, ainsi qu’en prébiotiques pour soutenir l’équilibre de la flore intestinale. Le produit est facilement soluble dans de l’eau, du lait ou des boissons végétales, et se distingue par son agréable goût de noix de coco. Il est recommandé pour les sportifs ou pour toute personne souhaitant augmenter son apport en protéines de manière pratique et savoureuse.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 1000,
-            "name": "JUS ET PULPE D'ALOE VERA AVEC DU JUS DE GOJI",
-            "image": "https://orianacosmetic.com/cdn/shop/files/JUS-ET-PULPE-D_ALOE-VERA-AVEC-DU-JUS-DE-GOJI_Chogan-264538779.png?v=1754103324&width=355",
-            "hint": "detox tea",
-            "price": 26.9,
-            "category": "minceur",
-            "description": "Le Jus et Pulpe d'Aloe Vera avec du Jus de Goji est un complément alimentaire qui combine les bienfaits naturels de l'Aloe Vera et du Goji pour favoriser le bien-être général. Ce produit est formulé pour soutenir la digestion, apporter une action antioxydante et purifier l’organisme. Il est particulièrement bénéfique pour la santé du transit intestinal et pour un effet apaisant sur le système digestif",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 349,
-            "name": "JUS ET PULPE D’ALOE VERA 99,5%",
-            "image": "https://orianacosmetic.com/cdn/shop/files/JUS-ET-PULPE-D_ALOE-VERA-99_5_Chogan-264528738.png?v=1754103311&width=690",
-            "hint": "detox tea",
-            "price": 24.9,
-            "category": "minceur",
-            "description": "Le Jus et Pulpe d’Aloe Vera est un complément alimentaire pur à 99,5%, conçu pour apporter les bienfaits de l'Aloe Vera de manière naturelle. Il aide à maintenir une bonne digestion et peut être utilisé pour ses propriétés apaisantes et hydratantes. Le produit est certifié pour sa pureté et contient des conservateurs naturels pour une meilleure conservation.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 456,
-            "name": "JUS ET PULPE d'ALOE VERA AVEC JUS DE MYRTILLE",
-            "image": "https://orianacosmetic.com/cdn/shop/files/JUS-ET-PULPE-d_ALOE-VERA-AVEC-JUS-DE-MYRTILLE_Chogan-264616978.png?v=1754103362&width=690",
-            "hint": "detox tea",
-            "price": 25.9,
-            "category": "minceur",
-            "description": "Le Jus et Pulpe d'Aloe Vera avec du Jus de Myrtille est un complément alimentaire alliant les propriétés de l'Aloe Vera et de la Myrtille, offrant une expérience saine et bénéfique pour l'organisme. Il est spécialement conçu pour soutenir la digestion, favoriser l'hydratation et posséder des effets antioxydants naturels. Ce produit est idéal pour purifier le corps et améliorer le bien-être général.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 297,
-            "name": "JUS ET PULPE d'ALOE VERA AVEC INFUSION DE THÉ VERT",
-            "image": "https://orianacosmetic.com/cdn/shop/files/JUS-ET-PULPE-d_ALOE-VERA-AVEC-INFUSION-DE-THE-VERT_Chogan-264644147.png?v=1754103389&width=690",
-            "hint": "detox tea",
-            "price": 25.9,
-            "category": "minceur",
-            "description": "Le Jus et Pulpe d'Aloe Vera avec Infusion de Thé Vert est un complément alimentaire unique qui associe les bienfaits de l'Aloe Vera et du thé vert. Il soutient le métabolisme, favorise la digestion et offre des propriétés antioxydantes grâce à l'infusion de thé vert. Ce produit est une excellente solution pour purifier l'organisme et améliorer le bien-être général tout en offrant une sensation de fraîcheur.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 239,
-            "name": "ELIX ACTIVE à l'extrait d’escargot",
-            "image": "https://orianacosmetic.com/cdn/shop/files/ELIX-ACTIVE-a-l_extrait-d_escargot_Chogan-264708253.png?v=1754103428&width=355",
-            "hint": "detox tea",
-            "price": 24.9,
-            "category": "minceur",
-            "description": "ELIX FLUID avec extrait d'escargot est un complément alimentaire sous forme de sirop, formulé pour favoriser la fonctionnalité des muqueuses du système respiratoire. Il contient de l'extrait d'escargot (Helix aspersa) ainsi que des extraits de plantes soigneusement sélectionnées, telles que l'Althaea (Althaea officinalis), l'Eucalyptus (Eucalyptus globulus), et le Sureau (Sambucus nigra). Ce sirop, aromatisé au citron, est conçu pour apaiser et soutenir le bien-être respiratoire.",
-            "subCategory": "complement-alimentaire"
-        },
-        {
-            "id": 339,
-            "name": "ELIX ACTIVE à l'extrait d’escargot",
-            "image": "https://orianacosmetic.com/cdn/shop/files/ELIX-FLUID-avec-extrait-d_escargot_Chogan-264682472.png?v=1754103402&width=690",
-            "hint": "detox tea",
-            "price": 29,
-            "category": "minceur",
-            "description": "ELIX ACTIVE est un complément alimentaire sous forme de sirop à base d'extrait d'escargot (Helix aspersa), enrichi d'extraits naturels d'Aloe Vera, de Fenouil et de Mauve. Sa formule douce et naturelle aide à réguler le transit intestinal tout en apportant un confort digestif optimal. Agréablement aromatisé à l’orange, ce produit s’intègre facilement dans la routine quotidienne.",
-            "subCategory": "complement-alimentaire"
         }
     ]
 }

--- a/src/app/catalogue/page.tsx
+++ b/src/app/catalogue/page.tsx
@@ -47,7 +47,7 @@ export default function CataloguePage() {
     }
   };
 
-  const subCategories = ['all', 'creme-de-visage', 'deodorant'];
+  const subCategories = [];
 
   return (
     <div className="flex flex-col min-h-dvh bg-background text-foreground font-body">

--- a/src/app/produits-minceur/page.tsx
+++ b/src/app/produits-minceur/page.tsx
@@ -8,7 +8,6 @@ import Footer from "@/components/layout/Footer";
 import { CurrencySwitcher } from "@/components/CurrencySwitcher";
 import { ProductCard } from '@/components/ProductCard';
 import { Cart } from '@/components/Cart';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface Product {
   id: number;
@@ -22,7 +21,6 @@ interface Product {
 
 export default function ProduitsMinceurPage() {
   const [produitsMinceur, setProduitsMinceur] = useState<Product[]>([]);
-  const [complementsAlimentaires, setComplementsAlimentaires] = useState<Product[]>([]);
 
   useEffect(() => {
     fetch('/produits.json')
@@ -30,7 +28,6 @@ export default function ProduitsMinceurPage() {
       .then(data => {
         const allSlimmingProducts = data.products.filter((p: Product) => p.category === 'minceur');
         setProduitsMinceur(allSlimmingProducts.filter((p: Product) => p.subCategory === 'produit-minceur'));
-        setComplementsAlimentaires(allSlimmingProducts.filter((p: Product) => p.subCategory === 'complement-alimentaire'));
       });
   }, []);
 
@@ -55,35 +52,18 @@ export default function ProduitsMinceurPage() {
                 <div className="mx-auto max-w-3xl text-center">
                     <Weight className="mx-auto h-12 w-12 text-primary animate-bounce" />
                     <h1 className="mt-4 font-headline text-4xl font-bold tracking-tight md:text-5xl">
-                        Nos Produits Minceur et Compléments Alimentaires
+                        Nos Produits Minceur
                     </h1>
                     <p className="mt-4 text-lg text-muted-foreground">
                        Une sélection de produits de haute qualité pour vous accompagner dans votre parcours bien-être et atteindre vos objectifs.
                     </p>
                 </div>
 
-                <Tabs defaultValue="produits-minceur" className="mt-12">
-                  <TabsList className="grid w-full grid-cols-2">
-                    <TabsTrigger value="produits-minceur">Produits Minceur</TabsTrigger>
-                    <TabsTrigger value="complements-alimentaires">Compléments Alimentaires</TabsTrigger>
-                  </TabsList>
-                  <TabsContent value="produits-minceur">
-                   
-                    <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 mt-8">
-                        {produitsMinceur.map((product) => (
-                            <ProductCard key={product.id} product={product} />
-                        ))}
-                    </div>
-                  </TabsContent>
-                  <TabsContent value="complements-alimentaires">
-                   
-                    <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 mt-8">
-                        {complementsAlimentaires.map((product) => (
-                            <ProductCard key={product.id} product={product} />
-                        ))}
-                    </div>
-                  </TabsContent>
-                </Tabs>
+                <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 mt-12">
+                    {produitsMinceur.map((product) => (
+                        <ProductCard key={product.id} product={product} />
+                    ))}
+                </div>
 
                  <div className="mt-16 text-center">
                     <h3 className="font-headline text-2xl font-bold">Intéressé(e) par un produit ?</h3>


### PR DESCRIPTION
This commit removes the following product categories and filters from the website as requested:
- "complément alimentaire"
- "produit entretien"
- "creme de-visage"
- "deodorant"

Changes include:
- Updating `public/produits.json` to remove the corresponding products.
- Removing the filter buttons from `src/app/catalogue/page.tsx`.
- Removing the "Compléments Alimentaires" tab and related logic from `src/app/produits-minceur/page.tsx`.