### PR TITLE
feat: Remove "Complément Alimentaire" tab and enhance design

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,14 +14,15 @@
     --card-foreground: 330 40% 10%;
     --popover: 40 50% 98%;
     --popover-foreground: 330 40% 10%;
-    --primary: 330 80% 65%; /* Soft Pink */
-    --primary-foreground: 0 0% 100%;
+    --primary: 45 90% 70%; /* Soft Gold */
+    --primary-foreground: 330 40% 10%; /* Dark Plum for contrast */
     --secondary: 340 60% 95%; /* Lighter Pink/Cream */
     --secondary-foreground: 330 40% 20%;
     --muted: 340 30% 93%;
     --muted-foreground: 330 20% 45%;
-    --accent: 45 90% 70%; /* Soft Gold */
-    --accent-foreground: 330 40% 15%;
+    --accent: 330 80% 65%; /* Soft Pink */
+    --accent-foreground: 0 0% 100%;
+    --gold: 45 90% 55%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
     --border: 340 20% 85%;
@@ -37,14 +38,15 @@
     --card-foreground: 340 10% 98%;
     --popover: 330 15% 10%;
     --popover-foreground: 340 10% 98%;
-    --primary: 330 70% 60%; /* Brighter Pink */
-    --primary-foreground: 0 0% 100%;
+    --primary: 45 80% 65%; /* Gold */
+    --primary-foreground: 330 40% 10%; /* Dark Plum for contrast */
     --secondary: 330 15% 18%;
     --secondary-foreground: 340 10% 98%;
     --muted: 330 10% 25%;
     --muted-foreground: 340 10% 65%;
-    --accent: 45 80% 65%; /* Gold */
-    --accent-foreground: 0 0% 98%;
+    --accent: 330 70% 60%; /* Brighter Pink */
+    --accent-foreground: 0 0% 100%;
+    --gold: 45 80% 60%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
     --border: 330 10% 25%;

--- a/src/app/produits-minceur/page.tsx
+++ b/src/app/produits-minceur/page.tsx
@@ -8,7 +8,6 @@ import Footer from "@/components/layout/Footer";
 import { CurrencySwitcher } from "@/components/CurrencySwitcher";
 import { ProductCard } from '@/components/ProductCard';
 import { Cart } from '@/components/Cart';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface Product {
   id: number;
@@ -22,15 +21,13 @@ interface Product {
 
 export default function ProduitsMinceurPage() {
   const [produitsMinceur, setProduitsMinceur] = useState<Product[]>([]);
-  const [complementsAlimentaires, setComplementsAlimentaires] = useState<Product[]>([]);
 
   useEffect(() => {
     fetch('/produits.json')
       .then(response => response.json())
       .then(data => {
-        const allSlimmingProducts = data.products.filter((p: Product) => p.category === 'minceur');
-        setProduitsMinceur(allSlimmingProducts.filter((p: Product) => p.subCategory === 'produit-minceur'));
-        setComplementsAlimentaires(allSlimmingProducts.filter((p: Product) => p.subCategory === 'complement-alimentaire'));
+        const allSlimmingProducts = data.products.filter((p: Product) => p.category === 'minceur' && p.subCategory === 'produit-minceur');
+        setProduitsMinceur(allSlimmingProducts);
       });
   }, []);
 
@@ -55,35 +52,18 @@ export default function ProduitsMinceurPage() {
                 <div className="mx-auto max-w-3xl text-center">
                     <Weight className="mx-auto h-12 w-12 text-primary animate-bounce" />
                     <h1 className="mt-4 font-headline text-4xl font-bold tracking-tight md:text-5xl">
-                        Nos Produits Minceur et Compléments Alimentaires
+                        Nos Produits Minceur
                     </h1>
                     <p className="mt-4 text-lg text-muted-foreground">
                        Une sélection de produits de haute qualité pour vous accompagner dans votre parcours bien-être et atteindre vos objectifs.
                     </p>
                 </div>
 
-                <Tabs defaultValue="produits-minceur" className="mt-12">
-                  <TabsList className="grid w-full grid-cols-2">
-                    <TabsTrigger value="produits-minceur">Produits Minceur</TabsTrigger>
-                    <TabsTrigger value="complements-alimentaires">Compléments Alimentaires</TabsTrigger>
-                  </TabsList>
-                  <TabsContent value="produits-minceur">
-
-                    <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 mt-8">
-                        {produitsMinceur.map((product) => (
-                            <ProductCard key={product.id} product={product} />
-                        ))}
-                    </div>
-                  </TabsContent>
-                  <TabsContent value="complements-alimentaires">
-
-                    <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 mt-8">
-                        {complementsAlimentaires.map((product) => (
-                            <ProductCard key={product.id} product={product} />
-                        ))}
-                    </div>
-                  </TabsContent>
-                </Tabs>
+                <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 mt-12">
+                    {produitsMinceur.map((product) => (
+                        <ProductCard key={product.id} product={product} />
+                    ))}
+                </div>
 
                  <div className="mt-16 text-center">
                     <h3 className="font-headline text-2xl font-bold">Intéressé(e) par un produit ?</h3>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,6 +45,7 @@ export default {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
         },
+        gold: 'hsl(var(--gold))',
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',


### PR DESCRIPTION
This commit addresses the user's request to remove the "Complément Alimentaire" tab from the `produits-minceur` page and to improve the site's design with gold accents.

- The `produits-minceur` page has been refactored to remove the tabbed interface, now only displaying slimming products.
- The site's primary color has been changed to a gold hue to create a more elegant and luxurious feel, as requested. This change is applied globally through the theme configuration.